### PR TITLE
test user model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,4 +25,4 @@
 .env
 
 # ignore local images (paperclip + fog)
-public/listings/
+public/listing*

--- a/app/controllers/listings_controller.rb
+++ b/app/controllers/listings_controller.rb
@@ -25,7 +25,7 @@ class ListingsController < ApplicationController
   def new
     @listing = current_user.listings.build
   end
-  
+
   # POST /listings
   # POST /listings.json
   def create

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -25,18 +25,17 @@ class User < ActiveRecord::Base
     with: /\A(\d{5}\z)|(\d{5}-\d{4}\z)/, presence: true
 
   after_create :init_karma
-  after_create :set_id
-  # Move to Messages Concern
-  def messages(id)
+
+  def messages(id) # todo: Move to Messages Concern
     self.mailbox.conversations.find(id)
         .messages.order(created_at: :desc)
   end
 
-  def url_params
+  def url_params # todo: move to route helper
     "#{self.id}/#{URI.escape(self.name)}"
   end
 
-  def user_img
+  def user_img # todo: rename
     "letters/#{self.name[0].downcase}.png"
   end
 
@@ -45,13 +44,4 @@ class User < ActiveRecord::Base
   def init_karma
     self.add_points(250)
   end
-
-  def set_id
-    now = Time.now
-    macro = now.strftime("%y%m").to_f
-    micro = now.strftime("%d%k").to_f
-
-    self.id = macro + self.id + micro
-  end
-
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,10 +1,17 @@
-require 'rails_helper'
-
 describe User do
   describe 'associations' do
-    # These models don't have a user_id foreign key(??), sync with ed
-    # it { should have_many :conversations } # ask about mailboxer gem magic
-    # it { should have_many :exchanges }
+    subject { build(:user) }
+
+    it 'has many exchanges' do
+      expect(subject.exchanges).to eq [] # breaks when you save..
+    end
+
+    #it 'has many conversations' do # breaks when you save...
+      #expect(subject.conversations).to eq []
+      #subject.save
+      #create(:user).send_message(subject, 'my funky message', 'my funky subject')
+      #expect(subject.conversations).to_not eq []
+    #end
     it { should have_many :listings }
     it { should have_many :listing_offers }
     it { should have_many :listing_asks }
@@ -18,5 +25,44 @@ describe User do
     it { should validate_presence_of :name }
     it { should allow_value(Faker::Address.zip_code).for :zip_code }
     it { should_not allow_value(Faker::Internet.user_name).for :zip_code }
+  end
+
+  describe '#create' do
+    it 'gives the user 250 karma points' do
+      expect(create(:user).points).to eq 250
+    end
+  end
+
+  describe '#messages' do
+    let(:sender) { create(:user) }
+    let(:receiver) { create(:user) }
+
+    context 'with a conversation' do
+      before do
+        sender.send_message(receiver, 'my funky message', 'my funky subject')
+      end
+
+      it 'returns the messages for a conversation' do
+        expect(receiver.messages(1)).to eq [Mailboxer::Message.last]
+      end
+    end
+  end
+
+  describe '#url_params' do
+    let(:name) { 'Jimmy Neutron' }
+    subject { create(:user, name: name) }
+
+    it 'is formatted with the user id and name' do
+      expect(subject.url_params).to eq '1/Jimmy%20Neutron'
+    end
+  end
+
+  describe '#user_img' do
+    let(:name) { 'Bob Dylan' }
+    subject { create(:user, name: name) }
+
+    it "is formatted by the user's first initial" do
+      expect(subject.user_img).to eq 'letters/b.png'
+    end
   end
 end


### PR DESCRIPTION
adds some specs for the user model

removes set_id (unnecessary time-based id generation, breaks when reloading/saving users as user persisted to db has different id than in-memory user object, doesn't look like anything was relying on how user ids were generated, only that they're unique)

Thoughts / reactions ?
